### PR TITLE
Fixes for exceptions caused by recent TLD updates

### DIFF
--- a/VisualStudio/src/CookingPatches.cs
+++ b/VisualStudio/src/CookingPatches.cs
@@ -302,7 +302,7 @@ namespace BetterWaterManagement
     {
         internal static bool Prefix(Panel_Cooking __instance)
         {
-            if (!InputManager.GetInventoryDropPressed(GameManager.Instance()))
+            if (!InputManager.GetInventoryDropPressed(__instance))
             {
                 return true;
             }

--- a/VisualStudio/src/PickUpWaterPatches.cs
+++ b/VisualStudio/src/PickUpWaterPatches.cs
@@ -219,7 +219,7 @@ namespace BetterWaterManagement
     {
         internal static void Postfix(Panel_PickWater __instance)
         {
-            if (InputManager.GetEquipPressed(GameManager.Instance()))
+            if (InputManager.GetEquipPressed(__instance))
             {
                 Traverse traverse = Traverse.Create(__instance);
 

--- a/VisualStudio/src/UseWaterPatches.cs
+++ b/VisualStudio/src/UseWaterPatches.cs
@@ -150,17 +150,16 @@ namespace BetterWaterManagement
             {
                 if (!WaterUtils.IsCooledDown(gearItem.m_CookingPotItem))
                 {
-                    GameManager.GetPlayerManagerComponent().ApplyFreezingBuff(20 * progress, 0.5f, 1 * progress);
-                    PlayerDamageEvent.SpawnAfflictionEvent("GAMEPLAY_WarmingUp", "GAMEPLAY_BuffHeader", "ico_injury_warmingUp", InterfaceManager.m_Panel_ActionsRadial.m_FirstAidBuffColor);
+                    GameManager.GetPlayerManagerComponent().ApplyFreezingBuff(20 * progress, 0.5f, 1 * progress, 1);
+                    InterfaceManager.m_Panel_HUD.ShowBuffNotification("GAMEPLAY_WarmingUp", "GAMEPLAY_BuffHeader", InterfaceManager.m_Panel_HUD.m_BuffSpriteFreezingBuff);
                 }
 
                 WaterUtils.SetWaterAmount(gearItem.m_CookingPotItem, waterSupply.m_VolumeInLiters);
                 Object.Destroy(waterSupply);
             }
 
-            if (waterSupply is WaterSourceSupply)
+            if (waterSupply is WaterSourceSupply waterSourceSupply)
             {
-                WaterSourceSupply waterSourceSupply = waterSupply as WaterSourceSupply;
                 waterSourceSupply.UpdateWaterSource();
             }
 

--- a/VisualStudio/src/UseWaterPatches.cs
+++ b/VisualStudio/src/UseWaterPatches.cs
@@ -55,7 +55,7 @@ namespace BetterWaterManagement
 
             for (int index = 0; index < GameManager.GetInventoryComponent().m_Items.Count; ++index)
             {
-                GearItem component = GameManager.GetInventoryComponent().m_Items[index].GetComponent<GearItem>();
+                GearItem component = GameManager.GetInventoryComponent().m_Items[index];
                 if (component.m_FoodItem != null && component.m_FoodItem.m_IsDrink)
                 {
                     if (component.m_IsInSatchel)


### PR DESCRIPTION
Some changes in recent TLD updates currently prevent the Better-Water-Management mod from working correctly:

- `Inventory#m_Items` now contains `GearItemObjects` instead of just plain `GameObjects`
- `ApplyFreezingBuff` now takes an extra argument that indicates the maximum duration of a freezing buff
- The method with which the freezing buff is shown on the HUD has changed

If you're having trouble building the DLL due to a strange dependency on .NET 4 coming from a game that's still using .NET 3.5 - I've left a tutorial on how to fix that on the modding discord.